### PR TITLE
fix: syntax highlight fails in html file

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "path": "./syntaxes/allay-injection.tmLanguage.json",
         "injectTo": [
           "text.html.markdown",
-          "text.html.basic"
+          "text.html"
         ]
       }
     ],

--- a/syntaxes/allay-injection.tmLanguage.json
+++ b/syntaxes/allay-injection.tmLanguage.json
@@ -1,6 +1,6 @@
 {
     "scopeName": "markdown.allay.injection",
-    "injectionSelector": "L:text.html.markdown, L:text.html.basic",
+    "injectionSelector": "L:text.html.markdown, L:text.html",
     "patterns": [
         { "include": "#command-block" },
         { "include": "#expression-block" },


### PR DESCRIPTION
今天发现html中不能正确高亮，检查发现是`injectTo`的`scope`有问题。应该是`text.html`，而非`text.html.basic`，后者不会起效。

修复后在html中可以正确高亮。

<img width="954" height="910" alt="image" src="https://github.com/user-attachments/assets/d09dee5d-4207-438b-851a-01386d22f695" />
